### PR TITLE
Update setup.py to fix pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ elif platform.architecture()[0] == "64bit":
 # Finding SFML path
 print("Searching for SFML installation...")
 sfml_path = ""
-for root, dirs, files in os.walk("C:\\"):
+root_path = "\\" if os.name == "posix" else "C:\\"
+for root, dirs, files in os.walk(root_path):
     valid_dirs = list(filter(lambda dir: dir.startswith("SFML"), dirs))
     for dir in valid_dirs:
         if os.path.exists(os.path.join(root, dir, 'lib')) and os.path.exists(os.path.join(root, dir, 'include')) and os.path.exists(os.path.join(root, dir, 'bin')):


### PR DESCRIPTION
Automatically detects SFML installation and includes it in compilation.

This means it should be able to work from pip install, whereas before it would fail due to missing SFML files. 

These changes were based on the changes by _jokoon_ in the thread at https://en.sfml-dev.org/forums/index.php?topic=24014.0, with the addition of searching for the SFML installation.

NOTE - this does not check if this is the latest installed version of SFML or if it was compiled with the same compiler, and it only checks drive C. These are potential future improvements.